### PR TITLE
Add phishing contact address for Strato

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -32,3 +32,9 @@
   links:
     - lang: "DE"
       url: "https://phishing-contact.ionos.de/de"
+
+- name: Strato
+  address: ""
+  links:
+    - lang: "DE"
+      url: "https://phishing-contact.strato.de/"


### PR DESCRIPTION
As with IONOS, no direct email address